### PR TITLE
Add default allow paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.web3j:solidity-gradle-plugin:0.1.3'
+        classpath 'org.web3j:solidity-gradle-plugin:0.1.4'
     }
 }
 
@@ -36,7 +36,7 @@ build file:
 
 ```groovy
 plugins {
-    id 'solidity' version '0.1.3'
+    id 'solidity' version '0.1.4'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,18 @@ solidity {
 
 The properties accepted by the DSL are listed in the following table:
 
-|  Name              | Type                | Default value    | Description                 |
-|--------------------|:-------------------:|:----------------:|-----------------------------|
-| `overwrite`        | `Boolean`           | `true`           | Overwrite existing files.   |
-| `optimize`         | `Boolean`           | `true`           | Enable byte code optimizer. |
-| `optimizeRuns`     | `Integer`           | `200`            | Set for how many contract runs to optimize. |
-| `prettyJson`       | `Boolean`           | `false`          | Output JSON in pretty format. Enables the combined JSON output. |
-| `ignoreMissing`    | `Boolean`           | `false`          | Ignore missing files. |
-| `allowPaths`       | `List<String>`      | `[]`             | Allow a given path for imports. |
-| `evmVersion`       | `EVMVersion`        | `BYZANTIUM`      | Select desired EVM version. |
-| `outputComponents` | `OutputComponent[]` | `[BIN, ABI]`     | List of output components to produce. |
+|  Name              | Type                | Default value                            | Description                 |
+|--------------------|:-------------------:|:----------------------------------------:|-----------------------------|
+| `overwrite`        | `Boolean`           | `true`                                   | Overwrite existing files.   |
+| `optimize`         | `Boolean`           | `true`                                   | Enable byte code optimizer. |
+| `optimizeRuns`     | `Integer`           | `200`                                    | Set for how many contract runs to optimize. |
+| `prettyJson`       | `Boolean`           | `false`                                  | Output JSON in pretty format. Enables the combined JSON output. |
+| `ignoreMissing`    | `Boolean`           | `false`                                  | Ignore missing files. |
+| `allowPaths`       | `List<String>`      | `[$projectDir/src/<name>/solidity, ...]` | Allow a given path for imports. |
+| `evmVersion`       | `EVMVersion`        | `BYZANTIUM`                              | Select desired EVM version. |
+| `outputComponents` | `OutputComponent[]` | `[BIN, ABI]`                             | List of output components to produce. |
+
+**Note:** The `allowPaths` property contains all project's Solidity source sets by default.
 
 ## Source sets
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'org.web3j'
-version = '0.1.3'
+version = '0.1.4'
 description = 'Solidity Gradle Plugin'
 sourceCompatibility = 1.8
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -41,6 +41,7 @@ class SolidityPlugin implements Plugin<Project> {
         target.afterEvaluate {
             sourceSets.all { SourceSet sourceSet ->
                 configureTask(target, sourceSet)
+                configureAllowPath(target, sourceSet)
             }
         }
     }
@@ -99,6 +100,11 @@ class SolidityPlugin implements Plugin<Project> {
                 "for $sourceSet.name source set."
 
         project.getTasks().getByName('build') dependsOn(compileTask)
+    }
+
+    private static void configureAllowPath(final Project project, final SourceSet sourceSet) {
+        def allowPath = "$project.projectDir/src/$sourceSet.name/$NAME"
+        project.solidity.allowPaths.add(allowPath)
     }
 
 }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -44,15 +44,6 @@ class SolidityPluginTest {
                 mavenCentral()
             }
         """
-
-        def settingsFile = testProjectDir.newFile("settings.gradle")
-        settingsFile << """
-            pluginManagement {
-                repositories {
-                    mavenCentral()
-                }
-            }
-        """
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses issue #3 by adding `$projectDir/src/<name>/solidity` for every project source set.