### PR TITLE
Make plugin work with Gradle 7.0;

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'idea'
-    id 'maven'
     id 'maven-publish'
     id 'groovy'
     id 'java-gradle-plugin'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityResolve.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityResolve.groovy
@@ -61,6 +61,7 @@ class SolidityResolve extends DefaultTask {
 
     @InputFiles
     @SkipWhenEmpty
+    @PathSensitive(value = PathSensitivity.NONE)
     FileTree getSources() {
         return sources
     }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -84,6 +84,13 @@ class SolidityPluginTest {
                     }
                 }
             }
+            tasks {
+                jar {
+                    // deal with implicit dependendency issue so that
+                    // compileSolidity can be "UP-TO-DATE" when re-ran
+                    mustRunAfter "compileSolidity"
+                }
+            }
         """
 
         def success = build()
@@ -121,6 +128,13 @@ class SolidityPluginTest {
                         exclude "$differentVersionsFolderName/**"
                         exclude "greeter/**"
                     }
+                }
+            }
+            tasks {
+                jar {
+                    // deal with implicit dependendency issue so that
+                    // compileSolidity can be "UP-TO-DATE" when re-ran
+                    mustRunAfter "compileSolidity"
                 }
             }
         """
@@ -162,6 +176,13 @@ class SolidityPluginTest {
                        exclude "$differentVersionsFolderName/**"
                    }
                }
+            }
+            tasks {
+                jar {
+                    // deal with implicit dependendency issue so that
+                    // compileSolidity can be "UP-TO-DATE" when re-ran
+                    mustRunAfter "compileSolidity"
+                }
             }
         """
 
@@ -239,6 +260,13 @@ class SolidityPluginTest {
                 allowPaths = ['/src/src/main/solidity']
                 version = '0.4.15'
             }
+            tasks {
+                jar {
+                    // deal with implicit dependendency issue so that
+                    // compileSolidity can be "UP-TO-DATE" when re-ran
+                    mustRunAfter "compileSolidity"
+                }
+            }
         """
 
         def success = build()
@@ -270,6 +298,13 @@ class SolidityPluginTest {
                         exclude "sol5/**"
                         exclude "openzeppelin/**"
                     }
+                }
+            }
+            tasks {
+                jar {
+                    // deal with implicit dependendency issue so that
+                    // compileSolidity can be "UP-TO-DATE" when re-ran
+                    mustRunAfter "compileSolidity"
                 }
             }
         """


### PR DESCRIPTION
### What does this PR do?
This PR bumps Gradle version to 7.0 and makes according adjustments, making the plugin compatible with Gradle 7.0

### Where should the reviewer start?
Some adjustment were made to tests because implicit dependency between task `compileSolidity` and `jar` meant that `compile Solidity` produced `SUCCESS` instead of `UP_TO_DATE` when re-executed (https://docs.gradle.org/7.0/userguide/validation_problems.html#implicit_dependency). I have fixed this my modifying test build files and keeping the same assertions. You may find a more elegant solution to this.

### Why is it needed?
To make plugin compatible with latest major version of Gradle.