### PR TITLE
Updated node plugin version to improve M1 mac support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
     junitVersion = '4.13'
     assertjVersion = '3.17.1'
     systemRulesVersion = '1.19.0'
-    nodePluginVersion = '3.2.0'
+    nodePluginVersion = '3.2.1'
 }
 
 dependencies {


### PR DESCRIPTION
### What does this PR do?
It updates the node plugin version so that web3j will now work on m1 macs.

Currently when trying to use the web3j gradle plugin which relies on this solidity plugin you get the following error:

`Could not determine the dependencies of task ':nodeSetup'.
> Failed to query the value of task ':nodeSetup' property 'nodeArchiveFile'.
   > Could not resolve all files for configuration ':detachedConfiguration1'.
      > Could not find org.nodejs:node:14.15.4.
        Searched in the following locations:
          - https://repo.maven.apache.org/maven2/org/nodejs/node/14.15.4/node-14.15.4.pom
          - https://repo.spring.io/milestone/org/nodejs/node/14.15.4/node-14.15.4.pom
          - https://repo.spring.io/snapshot/org/nodejs/node/14.15.4/node-14.15.4.pom
          - https://nodejs.org/dist/v14.15.4/node-v14.15.4-darwin-arm64.tar.gz
        Required by:
            project :`

Which has been fixed in 3.2.1 of the gradle node plugin.

See the last comments [here](https://github.com/node-gradle/gradle-node-plugin/pull/204) which explain that 3.2.1 contains the fix for this.


