### PR TITLE
Add support of Berlin and London evm versions

### DIFF
--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/EVMVersion.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/EVMVersion.groovy
@@ -22,7 +22,9 @@ enum EVMVersion {
     BYZANTIUM('byzantium'),
     CONSTANTINOPLE('constantinople'),
     PETERSBURG('petersburg'),
-    ISTANBUL('istanbul')
+    ISTANBUL('istanbul'),
+    BERLIN('berlin'),
+    LONDON('london')
 
     private String value
 


### PR DESCRIPTION
### What does this PR do?
Add support of the latest EVM versions Berlin and London

### Where should the reviewer start?
There is a single file changes

### Why is it needed?
At least two users publicly requested it. In general, the majority of just started projects target the latest evm versions and web3j does not support them yet. It might become an issue in attracting new users of library.

REF: 
https://github.com/web3j/solidity-gradle-plugin/issues/52 
https://github.com/web3j/web3j-gradle-plugin/issues/68

@SweeXordious FYI