### PR TITLE
Fix native ARM64 solc binary resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* Use native Linux ARM64 Solidity compiler binaries for solc versions >= 0.8.31 [#87](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/87)
+* Fix support for native Linux ARM64 Solidity compiler binaries for solc versions >= 0.8.31 [#90](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/90)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-*
+* Use native Linux ARM64 Solidity compiler binaries for solc versions >= 0.8.31 [#87](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/87)
 
 ### Features
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 }
 
 ext {
-    soktVersion = '0.6.0'
+    soktVersion = '0.7.0'
     kotlinxSerializationVersion = '1.6.3' // required to CompileStatic with sokt involved
     junitVersion = '5.9.3'
     assertjVersion = '3.25.3'

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.process.ExecOperations
 import org.web3j.sokt.SolcInstance
+import org.web3j.sokt.SolcRelease
 import org.web3j.sokt.SolidityFile
 import org.web3j.sokt.VersionResolver
 
@@ -151,16 +152,21 @@ abstract class SolidityCompile extends SourceTask {
             SolcInstance compilerInstance
 
             if (compilerExecutable == null) {
+                def versionResolver = new VersionResolver(".web3j")
                 if (compilerVersion != null) {
-                    def resolvedVersion = new VersionResolver(".web3j").getSolcReleases().stream().filter {
+                    def resolvedVersion = versionResolver.getSolcReleases().stream().filter {
                         it.version == version.get() && it.isCompatibleWithOs()
                     }.findAny().orElseThrow {
                         return new Exception("Failed to resolve Solidity version $version from available versions. " +
                                 "You may need to use a custom executable instead.")
                     }
-                    compilerInstance = new SolcInstance(resolvedVersion, ".web3j", false)
+                    compilerInstance = new SolcInstance(resolveReleaseForArchitecture(resolvedVersion), ".web3j", false)
                 } else {
-                    compilerInstance = solidityFile.getCompilerInstance(".web3j", true)
+                    def resolvedVersion = versionResolver.getLatestCompatibleVersion(solidityFile.versionPragma)
+                    if (resolvedVersion == null) {
+                        throw new Exception("No compatible solc release could be found for the file: ${solidityFile.sourceFile}")
+                    }
+                    compilerInstance = new SolcInstance(resolveReleaseForArchitecture(resolvedVersion), ".web3j", true, solidityFile)
                     compilerVersion = compilerInstance.solcRelease.version
                 }
 
@@ -205,5 +211,57 @@ abstract class SolidityCompile extends SourceTask {
 
     private static boolean supportsEvmVersionOption(String version) {
         return version.split('\\.').last().toInteger() >= 24 || version.split('\\.')[1].toInteger() > 4
+    }
+
+
+    /**
+     * Resolves the appropriate Solidity compiler binary for the current platform.
+     */
+    static SolcRelease resolveReleaseForArchitecture(SolcRelease release) {
+        if (release.linuxUrl == null) {
+            return release
+        }
+        def linuxUrl = linuxUrlForArchitecture(release.version, release.linuxUrl, System.getProperty("os.name"),
+                System.getProperty("os.arch"))
+
+        return new SolcRelease(release.version, release.windowsUrl, linuxUrl, release.macUrl)
+    }
+
+
+    /**
+     * Returns the native ARM64 solc URL on supported Linux systems; otherwise returns the original URL.
+     */
+    static String linuxUrlForArchitecture(String version, String linuxUrl, String osName, String osArch) {
+        if (isLinuxArm64(osName, osArch) && supportsNativeLinuxArm64(version)) {
+            return "https://github.com/ethereum/solidity/releases/download/v${version}/solc-linux-arm64"
+        }
+        return linuxUrl
+    }
+
+
+    /**
+     * Returns true if the current platform is Linux running on an ARM64 architecture.
+     */
+    private static boolean isLinuxArm64(String osName, String osArch) {
+        return osName.toLowerCase(Locale.ROOT).contains("linux") &&
+                ["aarch64", "arm64"].contains(osArch.toLowerCase(Locale.ROOT))
+    }
+
+    private static boolean supportsNativeLinuxArm64(String version) {
+        return compareVersions(version, "0.8.31") >= 0
+    }
+
+    private static int compareVersions(String version, String otherVersion) {
+        def left = version.tokenize('.').collect { it.toInteger() }
+        def right = otherVersion.tokenize('.').collect { it.toInteger() }
+
+        for (int i = 0; i < Math.max(left.size(), right.size()); i++) {
+            def leftValue = i < left.size() ? left[i] : 0
+            def rightValue = i < right.size() ? right[i] : 0
+            if (leftValue != rightValue) {
+                return leftValue <=> rightValue
+            }
+        }
+        return 0
     }
 }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -345,6 +345,48 @@ class SolidityPluginTest {
         assertEquals(SUCCESS, success.task(":compileSolidity").getOutcome())
     }
 
+    @Test
+    void linuxArm64UsesNativeSolcFromVersion0831() {
+        def linuxUrl = SolidityCompile.linuxUrlForArchitecture(
+                "0.8.35",
+                "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-linux-amd64",
+                "Linux",
+                "aarch64")
+
+        assertEquals("https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-linux-arm64", linuxUrl)
+    }
+
+    @Test
+    void linuxArm64UsesAmd64SolcBeforeVersion0831() {
+        def amd64Url = "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-linux-amd64"
+
+        def linuxUrl = SolidityCompile.linuxUrlForArchitecture("0.8.30", amd64Url, "Linux", "aarch64")
+
+        assertEquals(amd64Url, linuxUrl)
+    }
+
+    @Test
+    void linuxAmd64KeepsUsingAmd64Solc() {
+        def amd64Url = "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-linux-amd64"
+
+        def linuxUrl = SolidityCompile.linuxUrlForArchitecture("0.8.35", amd64Url, "Linux", "amd64")
+
+        assertEquals(amd64Url, linuxUrl)
+    }
+
+    @Test
+    void macKeepsExistingSolcBinary() {
+        def linuxUrl = "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-linux-amd64"
+
+        def result = SolidityCompile.linuxUrlForArchitecture(
+                "0.8.35",
+                linuxUrl,
+                "Mac OS X",
+                "aarch64")
+
+        assertEquals(linuxUrl, result)
+    }
+
     private BuildResult build() {
         return GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())


### PR DESCRIPTION
### What does this PR do?   
Fixes #87

Adds native Linux ARM64 Solidity compiler binary support.

For Linux ARM64 systems:
- Uses `solc-linux-arm64` binaries for Solidity versions >= 0.8.31.
- Keeps existing `solc-linux-amd64` behavior for older Solidity versions and non-ARM64 platforms.
- Applies the architecture-aware binary resolution for both explicitly configured versions and pragma-resolved versions.

### Where should the reviewer start?

Start reviewing:
- `src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy`

The new architecture detection and Solidity binary URL resolution logic is added there.

Tests are added in:
- `src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy`

### Why is it needed?

Solidity 0.8.31+ provides native Linux ARM64 compiler binaries.

Previously, the plugin always selected the Linux AMD64 binary, causing ARM64 environments (Apple Silicon Linux, AWS Graviton, etc.) to rely on emulation.

This change allows ARM64 systems to use the correct native compiler binary, improving compatibility and performance.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.

## Verification

Tested locally with Solidity 0.8.35.

Compilation successful (used locally published web3j-sokt)
<img width="1868" height="953" alt="Screenshot_20260628_115409" src="https://github.com/user-attachments/assets/73e36630-7bf4-46e0-a889-b49f8abb9ff9" />


