### PR TITLE
fix: build fails when project has no Solidity sources (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Bug Fixes
 
 * Fix support for native Linux ARM64 Solidity compiler binaries for solc versions >= 0.8.31 [#90](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/90)
+* Fix build failure when a project has no Solidity sources [#91](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/91)
 
 ### Features
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
@@ -27,9 +27,11 @@ abstract class SolidityExtractImports extends DefaultTask {
     @Input
     abstract Property<String> getProjectName()
 
-    // Note: intentionally not @SkipWhenEmpty. When a project has no Solidity sources this task
-    // must still run and emit a package.json (with empty dependencies); otherwise the downstream
-    // npmInstall / resolveSolidity tasks fail input validation on the missing file (issue #43).
+    /*
+     Note: intentionally not @SkipWhenEmpty. When a project has no Solidity sources this task
+     must still run and emit a package.json (with empty dependencies); otherwise the downstream
+     npmInstall / resolveSolidity tasks fail input validation on the missing file.
+    */
     @InputFiles
     @PathSensitive(value = PathSensitivity.RELATIVE)
     abstract ConfigurableFileCollection getSources()

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
@@ -27,9 +27,11 @@ abstract class SolidityExtractImports extends DefaultTask {
     @Input
     abstract Property<String> getProjectName()
 
+    // Note: intentionally not @SkipWhenEmpty. When a project has no Solidity sources this task
+    // must still run and emit a package.json (with empty dependencies); otherwise the downstream
+    // npmInstall / resolveSolidity tasks fail input validation on the missing file (issue #43).
     @InputFiles
     @PathSensitive(value = PathSensitivity.RELATIVE)
-    @SkipWhenEmpty
     abstract ConfigurableFileCollection getSources()
 
     @OutputFile

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -387,6 +387,37 @@ class SolidityPluginTest {
         assertEquals(linuxUrl, result)
     }
 
+    /**
+     * Regression test for issue #43 ("packageJsonFile doesn't have a configured value").
+     *
+     * <p>When a project applies the plugin but has no Solidity sources, the import-extraction task
+     * is skipped (it is {@code @SkipWhenEmpty}) and never produces its {@code package.json} output.
+     * That left {@code resolveSolidity} (and, historically, the node plugin's {@code npmInstall})
+     * with input properties pointing at files that do not exist, failing the build during task
+     * validation. Applying the plugin to a source-less project must simply succeed.
+     */
+    @Test
+    void buildSucceedsWithoutSoliditySources() throws IOException {
+        // Remove the sample sources copied in by setup() so the project has no .sol files.
+        testProjectDir.resolve("src/main/solidity").toFile().deleteDir()
+
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+        """)
+
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("build", "-s")
+                .withPluginClasspath()
+                .forwardOutput().with {
+                    gradleVersionUnderTest ? it.withGradleVersion(gradleVersionUnderTest) : it
+                }.build()
+
+        assertEquals(SUCCESS, result.task(":build").getOutcome())
+    }
+
     private BuildResult build() {
         return GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -388,13 +388,11 @@ class SolidityPluginTest {
     }
 
     /**
-     * Regression test for issue #43 ("packageJsonFile doesn't have a configured value").
+     * Verifies that applying the plugin to a project without Solidity sources completes successfully.
      *
-     * <p>When a project applies the plugin but has no Solidity sources, the import-extraction task
-     * is skipped (it is {@code @SkipWhenEmpty}) and never produces its {@code package.json} output.
-     * That left {@code resolveSolidity} (and, historically, the node plugin's {@code npmInstall})
-     * with input properties pointing at files that do not exist, failing the build during task
-     * validation. Applying the plugin to a source-less project must simply succeed.
+     * <p>When no Solidity files are present, the import extraction task is skipped and does not
+     * generate its {@code package.json} output. Downstream tasks must handle this case gracefully
+     * without failing task validation.
      */
     @Test
     void buildSucceedsWithoutSoliditySources() throws IOException {


### PR DESCRIPTION
### What does this PR do?

Fixes #43.

Applying the plugin to a project with **no Solidity sources** no longer fails the build during task validation.

#### Cause

`SolidityExtractImports` uses `@SkipWhenEmpty` on its `sources` input. When there are no `.sol` files, the task is skipped and never generates its `package.json` output. As a result, downstream tasks (`npmInstall` and `resolveSolidity`) receive input properties pointing to files/directories that do not exist, causing task validation to fail:

```text
Some problems were found with the configuration of task ':resolveSolidity':
  - property 'packageJson' specifies file '.../build/package.json' which doesn't exist
  - property 'nodeModules' specifies directory '.../build/node_modules' which doesn't exist
```

#### Fix

Remove `@SkipWhenEmpty` so `SolidityExtractImports` always executes and generates a `package.json` file. When no Solidity sources are present, it writes an empty `dependencies` section, matching the existing behavior for projects that contain Solidity sources but no imports.

### Where should the reviewer start?

- `src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy`
  - Removes `@SkipWhenEmpty`.
  - Adds a comment explaining why the task must always run.

- `src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy`
  - Adds `buildSucceedsWithoutSoliditySources`, which removes all sample Solidity sources and verifies that `build` succeeds.
  - This test fails before the change and passes afterward.

Since `@SkipWhenEmpty` only affects the empty-input case, this change does not alter behavior for projects that already contain Solidity sources.

### Why is it needed?

Applying the plugin to a source-less project (for example, a freshly created module or one where contracts have not yet been added) currently fails the build with a confusing `doesn't exist` validation error. This issue is reported in #43 and has also previously surfaced as `packageJsonFile doesn't have a configured value` during `npmInstall`.

As a workaround, users have been creating dummy `.sol` files to satisfy the plugin. Instead, the plugin should simply build successfully when there are no Solidity sources.

### Verification

A project applying the plugin with **no `.sol` files**.

**Before (issue reproduced — released `0.6.1`):**

fails during task validation.

<img width="1022" height="677" alt="Screenshot_20260706_235227" src="https://github.com/user-attachments/assets/c40ddaac-bdb0-4dd1-9a74-1ff625195126" />

**After (this fix — locally published):**

Running the same command on the same project completes successfully.

<img width="603" height="348" alt="Screenshot_20260706_235348" src="https://github.com/user-attachments/assets/9a3e7fc1-3e6b-44cd-8384-3322270e47af" />


## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.