### PR TITLE
fix: update README and add test for custom Solidity source directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Fix support for native Linux ARM64 Solidity compiler binaries for solc versions >= 0.8.31 [#90](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/90)
 * Fix build failure when a project has no Solidity sources [#91](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/91)
+* Fix incorrect `srcDir` closure syntax in SourceSets documentation causing `Unresolved reference` errors on Gradle 8.x [#92](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/92)
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,8 @@ directory for compiled code.
 sourceSets {
     main {
         solidity {
-            srcDir {
-                "my/custom/path/to/solidity"
-             }
-             output.resourcesDir = file('out/bin/compiledSol') 
+            srcDir 'my/custom/path/to/solidity'
+            output.resourcesDir = file('out/bin/compiledSol')
         }
     }
 }
@@ -92,9 +90,7 @@ flag values for different sourceSets.
 sourceSets {
     main {
         solidity {
-            srcDir {
-                "my/custom/path/to/solidity"
-            }
+            srcDir 'my/custom/path/to/solidity'
             output.resourcesDir = file('out/bin/compiledSol')
             evmVersion = 'ISTANBUL'
             optimize = true
@@ -104,6 +100,9 @@ sourceSets {
     }
 }
 ```
+
+For Kotlin DSL, configure the source path with `srcDir("my/custom/path/to/solidity")`.
+The `allowPaths` property controls Solidity import resolution only; it does not replace source directories.
 
 ## Gradle Node Plugin
 

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -251,6 +251,41 @@ class SolidityPluginTest {
     }
 
     @Test
+    void compileSolidityFromCustomSourceDirectory() throws IOException {
+        def customSourceDir = testProjectDir.resolve("src/test/resources/contracts/EvmCodes")
+        Files.createDirectories(customSourceDir)
+        // Use a self-contained contract (no imports) so the custom srcDir test is isolated
+        Files.copy(
+                testProjectDir.resolve("src/main/solidity/sol5/Greeter.sol"),
+                customSourceDir.resolve("Greeter.sol"),
+                StandardCopyOption.REPLACE_EXISTING
+        )
+
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+
+            sourceSets {
+                main {
+                    solidity {
+                        srcDir "src/test/resources/contracts/EvmCodes"
+                        include "Greeter.sol"
+                        output.resourcesDir = file("out/compiledSol")
+                    }
+                }
+            }
+        """)
+
+        def success = build()
+        assertEquals(SUCCESS, success.task(":compileSolidity").getOutcome())
+
+        def customOutputDir = testProjectDir.resolve("out/compiledSol/solidity")
+        assertTrue(Files.exists(customOutputDir.resolve("Greeter.abi")))
+        assertTrue(Files.exists(customOutputDir.resolve("Greeter.bin")))
+    }
+
+    @Test
     @Disabled("Requires a specific solc version on the machine to pass")
     void compileSolidityWithExecutable() throws IOException {
         Files.writeString(buildFile, """


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Gradle `SourceSets` configuration issue reported in #73, where users on Gradle 8.x received an `Unresolved reference: srcDir` error when following the documented `sourceSets` configuration.

The root cause was that both README examples used the following incorrect syntax:

```groovy
srcDir {
    "my/custom/path/to/solidity"
}
```

`SourceDirectorySet.srcDir()` expects the directory path as an argument, not as a closure. The correct Groovy DSL syntax is:

```groovy
srcDir 'my/custom/path/to/solidity'
```

This PR updates both README examples, adds the Kotlin DSL equivalent, and clarifies that `allowPaths` is only used for Solidity import resolution—not for selecting source directories.

A regression test is also added to verify that configuring a custom `srcDir` together with a custom `output.resourcesDir` successfully compiles contracts end-to-end.

### Changes included

#### `README.md`
- Fix both `sourceSets` examples:
  - `srcDir { "..." }` → `srcDir '...'`
- Add Kotlin DSL equivalent:
  - `srcDir("my/custom/path/to/solidity")`
- Clarify that `allowPaths` is **not** a source directory selector.

#### `src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy`
- Add `compileSolidityFromCustomSourceDirectory()`, an integration test that:
  - Configures a non-default `srcDir`
  - Configures a custom `output.resourcesDir`
  - Verifies that generated `.abi` and `.bin` files are written to the expected output directory

---

## Where should the reviewer start?

1. Review the `README.md` changes under the **Source sets** section. The fix is small but addresses the exact configuration users were copying from the documentation.
2. Review `SolidityPluginTest.groovy`, specifically the new `compileSolidityFromCustomSourceDirectory()` integration test, which validates the corrected configuration against a real Gradle build.

---

## Why is it needed?

Users following the documented configuration encountered errors because:

```groovy
srcDir {
    "..."
}
```

passes a `Closure` object rather than a directory path. `SourceDirectorySet.srcDir()` does not accept a no-argument closure returning a `String`, and Gradle 8.x surfaces this as a runtime configuration error.

Additionally, users attempted to use `allowPaths` as a workaround. While this created the output directory, no contracts were compiled because `allowPaths` only controls which directories `solc` may access for import resolution—it does **not** determine which Solidity source files are compiled.

---

## Verification

```bash
./gradlew test --tests "org.web3j.solidity.gradle.plugin.SolidityPluginTest.compileSolidityFromCustomSourceDirectory"
```

Output:
<img width="1295" height="223" alt="image" src="https://github.com/user-attachments/assets/3050a635-e667-4214-9815-1eb6c48b02dc" />


## Issues fixed / related

- Fixes #73

---

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.