### PR TITLE
feat: add packages property to declare additional npm packages (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#40](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/40)
+* Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#93](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/93)
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*
+* Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#40](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/40)
 
 ### BREAKING CHANGES
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The properties accepted by the DSL are listed in the following table:
 | `ignoreMissing`            | `Boolean`                   | `false`                                           | Ignore missing files.                                           |
 | `allowPaths`               | `List<String>`              | `['src/main/solidity', 'src/test/solidity', ...]` | Allow a given path for imports.                                 |
 | `pathRemappings`           | `Map<String, String>`        | `[ : ]`                                           | Remaps contract imports to target path.                         |
+| `packages`                 | `Map<String, String>`        | `[ : ]`                                           | Additional npm packages (name to version) to resolve.           |
 | `evmVersion`               | `EVMVersion`                | `BYZANTIUM`                                       | Select desired EVM version.                                     |
 | `outputComponents`         | `OutputComponent[]`         | `[BIN, ABI]`                                      | List of output components to produce.                           |
 | `combinedOutputComponents` | `CombinedOutputComponent[]` | `[BIN, BIN_RUNTIME, SRCMAP, SRCMAP_RUNTIME]`      | List of output components in combined JSON output.              |
@@ -128,6 +129,25 @@ modules under the same directory.
 
 **Note:** In case of problems with the `package.json` file, you can delete it, and it will be regenerated with the
 latest versions.
+
+### Resolving additional packages
+
+Only scoped imports (e.g. `@openzeppelin/contracts`) written directly in your `.sol` files are detected
+automatically, and they are always resolved at their `latest` version. Use the `packages` property to declare
+extra npm packages that are not detected automatically, or to pin a specific version:
+
+```groovy
+solidity {
+    packages = [
+        '@consensys-software/permissioning-smart-contracts': 'latest',
+        '@uniswap/v3-core'                                 : '1.0.1'
+    ]
+}
+```
+
+Declared packages are added to the generated `package.json`, installed by npm and remapped automatically, so there
+is no need to disable `resolvePackages` or configure `pathRemappings` manually. A version declared here takes
+precedence over a version detected from imports.
 
 ## Plugin tasks
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
@@ -69,6 +69,8 @@ abstract class SolidityExtension {
 
     abstract MapProperty<String, String> getPathRemappings()
 
+    abstract MapProperty<String, String> getPackages()
+
     abstract Property<EVMVersion> getEvmVersion()
 
     abstract ListProperty<OutputComponent> getOutputComponents()

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtractImports.groovy
@@ -17,6 +17,7 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
@@ -26,6 +27,16 @@ abstract class SolidityExtractImports extends DefaultTask {
 
     @Input
     abstract Property<String> getProjectName()
+
+    /**
+     * Additional npm packages to resolve, mapped to their version (e.g. {@code 'latest'}).
+     * <p>
+     * These are merged into the generated {@code package.json} on top of the packages detected
+     * from Solidity imports, allowing users to declare dependencies that are not directly imported
+     * or to pin a specific version. Explicitly declared versions take precedence over detected ones.
+     */
+    @Input
+    abstract MapProperty<String, String> getPackages()
 
     /*
      Note: intentionally not @SkipWhenEmpty. When a project has no Solidity sources this task
@@ -45,10 +56,16 @@ abstract class SolidityExtractImports extends DefaultTask {
 
     @TaskAction
     void resolveSolidity() {
-        final Set<String> packages = new TreeSet<>()
+        final Map<String, String> dependencies = new TreeMap<>()
 
         sources.each { contract ->
-            packages.addAll(ImportsResolver.extractImports(contract))
+            ImportsResolver.extractImports(contract).each { detected ->
+                dependencies.put(detected, "latest")
+            }
+        }
+
+        getPackages().get().each { name, version ->
+            dependencies.put(name, version)
         }
 
         final jsonMap = [
@@ -56,9 +73,7 @@ abstract class SolidityExtractImports extends DefaultTask {
                 "description" : "",
                 "repository"  : "",
                 "license"     : "UNLICENSED",
-                "dependencies": packages.collectEntries {
-                    [(it): "latest"]
-                }
+                "dependencies": dependencies
         ]
 
         packageJson.get().asFile.text = new JsonBuilder(jsonMap).toPrettyString()

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -62,9 +62,11 @@ class SolidityPlugin implements Plugin<Project> {
     }
 
     private static void configureSolidityResolve(Project project, DirectoryProperty nodeProjectDir) {
+        def solidity = project.extensions.getByType(SolidityExtension)
         def extractSolidityImports = project.tasks.register("extractSolidityImports", SolidityExtractImports) {
             it.description = "Extracts imports of external Solidity contract modules."
             it.packageJson.set(nodeProjectDir.file("package.json"))
+            it.packages.convention(solidity.packages)
         }
         def npmInstall = project.tasks.named(NpmInstallTask.NAME) {
             it.dependsOn(extractSolidityImports)

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+import groovy.json.JsonSlurper
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -449,6 +451,56 @@ class SolidityPluginTest {
                 }.build()
 
         assertEquals(SUCCESS, result.task(":build").getOutcome())
+    }
+
+    /**
+     * Verifies that packages declared via the {@code packages} DSL property are written into the
+     * generated {@code package.json}, and that an explicitly declared version takes precedence over
+     * the {@code latest} version used for packages detected from Solidity imports.
+     */
+    @Test
+    void declaredPackagesAreAddedToPackageJson() throws IOException {
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+            sourceSets {
+                main {
+                    solidity {
+                        exclude "minimal_forwarder/**"
+                        exclude "sol5/**"
+                        exclude "common/**"
+                        exclude "eip/**"
+                        exclude "$differentVersionsFolderName/**"
+                        exclude "greeter/**"
+                    }
+                }
+            }
+            solidity {
+                packages = [
+                    '@custom-org/custom-lib'  : '1.2.3',
+                    '@openzeppelin/contracts' : '4.9.0'
+                ]
+            }
+        """)
+
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("extractSolidityImports", "-s")
+                .withPluginClasspath()
+                .forwardOutput().with {
+                    gradleVersionUnderTest ? it.withGradleVersion(gradleVersionUnderTest) : it
+                }.build()
+
+        assertEquals(SUCCESS, result.task(":extractSolidityImports").getOutcome())
+
+        def packageJson = testProjectDir.resolve("build/package.json")
+        assertTrue(Files.exists(packageJson))
+
+        def dependencies = new JsonSlurper().parse(packageJson.toFile())['dependencies'] as Map
+        assertEquals('1.2.3', dependencies['@custom-org/custom-lib'])
+        // Declared version overrides the "latest" used for imports detected from sources.
+        assertEquals('4.9.0', dependencies['@openzeppelin/contracts'])
     }
 
     private BuildResult build() {


### PR DESCRIPTION
## What does this PR do?

This PR resolves #40 by adding a new `packages` property to the `solidity` DSL, allowing users to declare additional npm packages (with an optional version) to be resolved automatically.

Until now, only scoped imports (e.g. `@openzeppelin/contracts`) written directly in `.sol` files were detected, and they were always resolved at their `latest` version. Anything else required disabling `resolvePackages` and hand-writing `pathRemappings`:

```groovy
// Old workaround
solidity {
    resolvePackages = false
    pathRemappings = ['@uniswap': "$projectDir/node_modules/@uniswap"]
}
```

With the new property, declared packages are added to the generated `package.json`, installed by npm and remapped automatically — no manual `pathRemappings` needed. A declared version also takes precedence over the `latest` used for detected imports, so versions can be pinned:

```groovy
solidity {
    packages = [
        '@consensys-software/permissioning-smart-contracts': 'latest',
        '@uniswap/v3-core'                                 : '1.0.1'
    ]
}
```

### Changes included

#### `SolidityExtension.groovy`
- Add `MapProperty<String, String> getPackages()` (npm package name → version).

#### `SolidityExtractImports.groovy`
- Add a `packages` task input and merge it into the generated `package.json` dependencies on top of the packages detected from imports. Explicitly declared versions override the detected `latest`.

#### `SolidityPlugin.groovy`
- Wire the extension's `packages` property into the `extractSolidityImports` task via convention.

#### `README.md`
- Document the `packages` property in the DSL table and add a **Resolving additional packages** section.

#### `SolidityPluginTest.groovy`
- Add `declaredPackagesAreAddedToPackageJson()` verifying declared packages land in `package.json` and that a declared version overrides the detected `latest`.

---

## Where should the reviewer start?

1. `SolidityExtractImports.resolveSolidity()` — the merge logic between detected imports and declared packages.
2. `SolidityExtension.groovy` and `SolidityPlugin.groovy` — the new property and its wiring.
3. `SolidityPluginTest.declaredPackagesAreAddedToPackageJson()` — validates the behaviour against a real Gradle build.

---

## Why is it needed?

The import scanner only picks up scoped `@scope/pkg` imports found directly in `.sol` files and always pins them to `latest`. Users who need a package that isn't auto-detected, or who need a specific version, were forced to turn off package resolution entirely and manage `pathRemappings` by hand. The `packages` property gives a first-class, declarative way to do this while keeping automatic resolution intact.

---

## Verification

```bash
./gradlew test --tests "org.web3j.solidity.gradle.plugin.SolidityPluginTest.declaredPackagesAreAddedToPackageJson"
```

<img width="1307" height="214" alt="image" src="https://github.com/user-attachments/assets/34eeedad-1b5b-4c51-b860-e9d51a8c2899" />


---

## Issues fixed / related

- Fixes #40

---

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
