### PR TITLE
fix: update sonatype repo URL and bump web3j-sokt to 0.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 }
 
 ext {
-    soktVersion = '0.6.0'
+    soktVersion = '0.7.0'
     kotlinxSerializationVersion = '1.6.3' // required to CompileStatic with sokt involved
     junitVersion = '5.9.3'
     assertjVersion = '3.25.3'

--- a/gradle/repositories/build.gradle
+++ b/gradle/repositories/build.gradle
@@ -1,5 +1,4 @@
 repositories {
     mavenCentral()
-    maven { url = 'https://oss.sonatype.org/content/repositories/releases/' }
-    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven { url = 'https://central.sonatype.com/repository/maven-snapshots/' }
 }


### PR DESCRIPTION
The old oss.sonatype.org URLs are no longer reliable and cause 504 errors during builds, so replaced them with the current central.sonatype.com snapshot URL.

Also bumped web3j-sokt from 0.6.0 to 0.7.0. The older version was crashing on compileSolidity because the solc release JSON now includes a linux_arm64_url field that 0.6.0 didn't handle - it threw an unknown key error. 0.7.0 handles it correctly.
