### PR TITLE
feat: add viaIr property to enable --via-ir compilation pipeline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#93](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/93)
+* Add `viaIr` property to enable the `--via-ir` compilation pipeline [#83](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/83)
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#93](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/93)
-* Add `viaIr` property to enable the `--via-ir` compilation pipeline [#83](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/83)
+* Add `viaIr` property to enable the `--via-ir` compilation pipeline [#95](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/95)
 
 ### BREAKING CHANGES
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
@@ -47,6 +47,7 @@ abstract class DefaultSoliditySourceSet extends DefaultSourceDirectorySet implem
         optimize.convention(solidity.optimize)
         optimizeRuns.convention(solidity.optimizeRuns)
         ignoreMissing.convention(solidity.ignoreMissing)
+        viaIr.convention(solidity.viaIr)
     }
 
     @Override

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
@@ -57,6 +57,9 @@ abstract class SolidityCompile extends SourceTask {
     abstract Property<Boolean> getIgnoreMissing()
 
     @Input
+    abstract Property<Boolean> getViaIr()
+
+    @Input
     abstract SetProperty<String> getAllowPaths()
 
     @Input
@@ -123,6 +126,10 @@ abstract class SolidityCompile extends SourceTask {
 
             if (ignoreMissing.get()) {
                 options.add('--ignore-missing')
+            }
+
+            if (viaIr.get()) {
+                options.add('--via-ir')
             }
 
             if (!allowPaths.get().isEmpty() || !imports.isEmpty()) {

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
@@ -36,6 +36,7 @@ abstract class SolidityExtension {
         optimizeRuns.convention(0)
         prettyJson.convention(false)
         ignoreMissing.convention(false)
+        viaIr.convention(false)
         outputComponents.convention([
                 OutputComponent.BIN,
                 OutputComponent.ABI,
@@ -64,6 +65,8 @@ abstract class SolidityExtension {
     abstract Property<Boolean> getOverwrite()
 
     abstract Property<Boolean> getIgnoreMissing()
+
+    abstract Property<Boolean> getViaIr()
 
     abstract SetProperty<String> getAllowPaths()
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -144,6 +144,7 @@ class SolidityPlugin implements Plugin<Project> {
             it.optimizeRuns.convention(soliditySourceSet.optimizeRuns)
             it.evmVersion.convention(soliditySourceSet.evmVersion)
             it.ignoreMissing.convention(soliditySourceSet.ignoreMissing)
+            it.viaIr.convention(soliditySourceSet.viaIr)
 
             it.resolvedImports.set(solidity.resolvePackages.flatMap {
                 it ? resolveSolidity.flatMap { it.allImports } : emptyImports(project)

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
@@ -40,4 +40,6 @@ interface SoliditySourceSet extends SourceDirectorySet {
 
     Property<Boolean> getIgnoreMissing()
 
+    Property<Boolean> getViaIr()
+
 }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -503,6 +503,37 @@ class SolidityPluginTest {
         assertEquals('4.9.0', dependencies['@openzeppelin/contracts'])
     }
 
+
+    @Test
+    void viaIrOptionCompilesSolidity() throws IOException {
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+            solidity {
+                viaIr = true
+                resolvePackages = false
+            }
+            sourceSets {
+                main {
+                    solidity {
+                        exclude "minimal_forwarder/**"
+                        exclude "eip/**"
+                        exclude "greeter/**"
+                        exclude "common/**"
+                        exclude "openzeppelin/**"
+                        exclude "$differentVersionsFolderName/**"
+                    }
+                }
+            }
+        """)
+
+        def result = build()
+
+        assertEquals(SUCCESS, result.task(":compileSolidity").getOutcome())
+    }
+
+
     private BuildResult build() {
         return GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())


### PR DESCRIPTION
## What does this PR do?

This PR resolves #83 by adding a new `viaIr` property to the `solidity` DSL, allowing users to enable Solidity's IR-based (`--via-ir`) compilation pipeline.

When `viaIr = true`, the `--via-ir` flag is passed to `solc`, so compilation goes through the Yul intermediate representation instead of the legacy code generator. This unlocks more advanced optimizations and is required by some contracts (e.g. those that would otherwise hit "Stack too deep" errors). The property defaults to `false`, preserving the existing behaviour.

```groovy
solidity {
    viaIr = true
}
```

Like the other compiler options (`optimize`, `evmVersion`, etc.), `viaIr` can also be overridden per source set:

```groovy
sourceSets {
    main {
        solidity {
            viaIr = true
        }
    }
}
```

### Changes included

#### `SolidityExtension.groovy`
- Add `Property<Boolean> getViaIr()` with a `false` convention default.

#### `SoliditySourceSet.groovy` / `DefaultSoliditySourceSet.groovy`
- Expose `viaIr` at the source-set level, defaulting to the extension value so it can be overridden per source set (same convention chain as `optimize`, `ignoreMissing`, etc.).

#### `SolidityCompile.groovy`
- Add a `@Input Property<Boolean> getViaIr()` task input and append `--via-ir` to the `solc` invocation when it is `true`.

#### `SolidityPlugin.groovy`
- Wire the source set's `viaIr` property into the `SolidityCompile` task via convention.

#### `CHANGELOG.md`
- Add a changelog entry under the upcoming release's **Features** section.

#### `SolidityPluginTest.groovy`
- Add `viaIrOptionCompilesSolidity()` verifying that a project compiles successfully with `viaIr = true`.

---

## Where should the reviewer start?

1. `SolidityCompile.compileSolidity()` — where `--via-ir` is appended to the `solc` options.
2. `SolidityExtension.groovy`, `SoliditySourceSet.groovy` and `SolidityPlugin.groovy` — the new property and its convention wiring.
3. `SolidityPluginTest.viaIrOptionCompilesSolidity()` — validates the behaviour against a real Gradle build.

---

## Why is it needed?

The `--via-ir` pipeline is the recommended way to compile contracts that exceed the legacy code generator's limits (most notably "Stack too deep" errors) and enables the full Yul optimizer. Previously there was no way to enable it through the plugin — users had to fall back to a custom `executable` or compile outside Gradle. The `viaIr` property makes this a first-class, declarative option consistent with the rest of the `solidity` DSL.

---

## Verification

```bash
./gradlew test --tests "org.web3j.solidity.gradle.plugin.SolidityPluginTest.viaIrOptionCompilesSolidity"
```

```
SolidityPluginTest > viaIrOptionCompilesSolidity() PASSED

BUILD SUCCESSFUL
```

---

## Issues fixed / related

- Fixes #83

---

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
