### PR TITLE
feat: allows the plugin to be applied without invoking the solidity compiler or the NodeJs/npm machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#93](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/93)
 * Add `viaIr` property to enable the `--via-ir` compilation pipeline [#95](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/95)
-* Add `solidity.compilerEnabled` flag to apply the plugin without the Solidity compiler or the Node/npm integration [#74](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/74)
+* Add `solidity.compilerEnabled` flag to apply the plugin without the Solidity compiler or the Node/npm integration [#96](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/96)
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * Add `packages` property to declare additional npm packages (with optional version pinning) to resolve, without disabling `resolvePackages` or configuring `pathRemappings` manually [#93](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/pull/93)
+* Add `solidity.compilerEnabled` flag to apply the plugin without the Solidity compiler or the Node/npm integration [#74](https://github.com/LFDT-web3j/web3j-solidity-gradle-plugin/issues/74)
 
 ### BREAKING CHANGES
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ The properties accepted by the DSL are listed in the following table:
 | `version`                  | `String`                    | `null` (defined by contract's pragma)             | Solidity compiler version.                                      |
 | `overwrite`                | `Boolean`                   | `true`                                            | Overwrite existing files.                                       |
 | `resolvePackages`          | `Boolean`                   | `true`                                            | Resolve third-party contract packages.                          |           
+| `compilerEnabled`          | `Boolean`                   | `true`                                            | Compile Solidity sources; disables compiler & Node when false.  |
 | `optimize`                 | `Boolean`                   | `true`                                            | Enable byte code optimizer.                                     |
 | `optimizeRuns`             | `Integer`                   | `200`                                             | Set for how many contract runs to optimize.                     |
+| `viaIr`                    | `Boolean`                   | `false`                                           | Enable the IR-based (`--via-ir`) compilation pipeline.          |
 | `prettyJson`               | `Boolean`                   | `false`                                           | Output JSON in pretty format. Enables the combined JSON output. |
 | `ignoreMissing`            | `Boolean`                   | `false`                                           | Ignore missing files.                                           |
 | `allowPaths`               | `List<String>`              | `['src/main/solidity', 'src/test/solidity', ...]` | Allow a given path for imports.                                 |
@@ -67,6 +69,20 @@ solidity {
     for all available versions.
   * `allowPaths` contains all project's Solidity source sets by default.
 
+### IR-based compilation (`--via-ir`)
+
+By default `solc` compiles through the legacy code generator. Set `viaIr = true` to compile through the
+Yul intermediate representation (the `--via-ir` pipeline) instead. This enables the full optimizer and can
+resolve `Stack too deep` errors that the legacy pipeline cannot handle:
+
+```groovy
+solidity {
+    viaIr = true
+}
+```
+
+The flag defaults to `false` and, like the other compiler options, can also be overridden per source set.
+
 ## Source sets
 
 By default, all `.sol` files in `$projectDir/src/main/solidity` and `$projectDir/src/test/solidity` will be processed by
@@ -84,8 +100,8 @@ sourceSets {
 }
 ```
 
-Now with solidity gradle plugin version 0.4.2, you can set different solidity versions, evmVersions, optimize flag, optimizeRuns and ignoreMissing 
-flag values for different sourceSets.
+Now with solidity gradle plugin version 0.4.2, you can set different solidity versions, evmVersions, optimize flag, optimizeRuns, ignoreMissing
+and viaIr flag values for different sourceSets.
 
 ```groovy
 sourceSets {
@@ -96,6 +112,7 @@ sourceSets {
             evmVersion = 'ISTANBUL'
             optimize = true
             optimizeRuns = 200
+            viaIr = true
             version = '0.8.12'
         }
     }
@@ -104,6 +121,26 @@ sourceSets {
 
 For Kotlin DSL, configure the source path with `srcDir("my/custom/path/to/solidity")`.
 The `allowPaths` property controls Solidity import resolution only; it does not replace source directories.
+
+## Applying the plugin without the compiler
+
+By default, applying the plugin registers the Solidity `compile` tasks and wires in the
+[Node plugin](https://github.com/node-gradle/gradle-node-plugin) to resolve contract dependencies, which runs
+`npmInstall` automatically. If you only need the plugin's source sets — for example to generate contract wrappers
+from existing `.abi` files — set `compilerEnabled = false`:
+
+```groovy
+solidity {
+    compilerEnabled = false
+}
+```
+
+With this flag disabled:
+
+  * the `compileSolidity` tasks are skipped, so no `solc` compiler is resolved, downloaded or executed;
+  * the `resolveSolidity` / `npmInstall` chain is never added to the task graph, so **NodeJS and npm are not required**.
+
+To keep compilation but skip only the Node/npm integration, use `resolvePackages = false` instead.
 
 ## Gradle Node Plugin
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityExtension.groovy
@@ -32,6 +32,7 @@ abstract class SolidityExtension {
     SolidityExtension() {
         optimize.convention(true)
         resolvePackages.convention(true)
+        compilerEnabled.convention(true)
         overwrite.convention(true)
         optimizeRuns.convention(0)
         prettyJson.convention(false)
@@ -56,6 +57,14 @@ abstract class SolidityExtension {
     abstract Property<Boolean> getOptimize()
 
     abstract Property<Boolean> getResolvePackages()
+
+    /**
+     * When {@code false}, Solidity compilation is skipped: the {@code compileSolidity} tasks do not
+     * run (so no solc compiler is resolved, downloaded or executed) and package resolution is not
+     * triggered. Useful when the plugin is applied only to set up source sets or to generate
+     * wrappers from existing {@code .abi} files. Defaults to {@code true}.
+     */
+    abstract Property<Boolean> getCompilerEnabled()
 
     abstract Property<Integer> getOptimizeRuns()
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -122,8 +122,19 @@ class SolidityPlugin implements Plugin<Project> {
         def soliditySourceSet = sourceSet.extensions.getByType(SoliditySourceSet)
         def resolveSolidity = project.tasks.named('resolveSolidity', SolidityResolve)
 
+        // Skip compilation entirely (no solc resolution/download/execution) when disabled.
+        def compilerEnabled = solidity.compilerEnabled
+
+        // Resolve npm packages only when both compilation and package resolution are enabled;
+        // otherwise the Node/npm resolve chain is never pulled into the task graph.
+        def shouldResolvePackages = compilerEnabled.zip(solidity.resolvePackages) { enabled, resolve ->
+            enabled && resolve
+        }
+
         def compileTask = project.tasks.register(sourceSet.getTaskName("compile", "Solidity"), SolidityCompile) {
             it.description = "Compiles $sourceSet.name Solidity source."
+
+            it.onlyIf { compilerEnabled.get() }
 
             it.source = soliditySourceSet
             it.destinationDirectory.convention(soliditySourceSet.destinationDirectory)
@@ -145,8 +156,8 @@ class SolidityPlugin implements Plugin<Project> {
             it.evmVersion.convention(soliditySourceSet.evmVersion)
             it.ignoreMissing.convention(soliditySourceSet.ignoreMissing)
 
-            it.resolvedImports.set(solidity.resolvePackages.flatMap {
-                it ? resolveSolidity.flatMap { it.allImports } : emptyImports(project)
+            it.resolvedImports.set(shouldResolvePackages.flatMap { resolve ->
+                resolve ? resolveSolidity.flatMap { it.allImports } : emptyImports(project)
             })
         }
 

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -26,9 +26,11 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 class SolidityPluginTest {
@@ -501,6 +503,66 @@ class SolidityPluginTest {
         assertEquals('1.2.3', dependencies['@custom-org/custom-lib'])
         // Declared version overrides the "latest" used for imports detected from sources.
         assertEquals('4.9.0', dependencies['@openzeppelin/contracts'])
+    }
+
+    /**
+     * With {@code solidity.compilerEnabled = false} the plugin can be applied without invoking
+     * the Solidity compiler or the Node/npm machinery: the compile task is skipped (so no solc is
+     * resolved, downloaded or executed) and the {@code resolveSolidity} / {@code npmInstall} chain
+     * is never pulled into the task graph.
+     */
+    @Test
+    void disablingCompilerSkipsCompilationAndNode() throws IOException {
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+            solidity {
+                compilerEnabled = false
+            }
+        """)
+
+        def result = build()
+
+        assertEquals(SUCCESS, result.task(":build").getOutcome())
+        assertEquals(SKIPPED, result.task(":compileSolidity").getOutcome())
+        assertNull(result.task(":resolveSolidity"))
+        assertNull(result.task(":npmInstall"))
+    }
+
+    /**
+     * {@code solidity.resolvePackages = false} disables only the Node/npm integration.
+     * Compilation still happens, but the {@code resolveSolidity} / {@code npmInstall} chain
+     * is never pulled into the task graph.
+     */
+    @Test
+    void disablingPackageResolutionSkipsNodeButStillCompiles() throws IOException {
+        Files.writeString(buildFile, """
+            plugins {
+               id 'org.web3j.solidity'
+            }
+            solidity {
+                resolvePackages = false
+            }
+            sourceSets {
+                main {
+                    solidity {
+                        exclude "minimal_forwarder/**"
+                        exclude "eip/**"
+                        exclude "greeter/**"
+                        exclude "common/**"
+                        exclude "openzeppelin/**"
+                        exclude "$differentVersionsFolderName/**"
+                    }
+                }
+            }
+        """)
+
+        def result = build()
+
+        assertEquals(SUCCESS, result.task(":compileSolidity").getOutcome())
+        assertNull(result.task(":resolveSolidity"))
+        assertNull(result.task(":npmInstall"))
     }
 
     private BuildResult build() {


### PR DESCRIPTION
## What does this PR do?

This PR resolves #74 by adding a new `compilerEnabled` property to the `solidity` DSL, allowing the plugin to be applied without invoking the Solidity compiler or the NodeJS/npm machinery.

By default, applying the plugin registers the `compileSolidity` tasks and wires in the Node plugin to resolve contract dependencies, which runs `npmInstall` automatically. Some projects only need the plugin's source sets — for example to generate contract wrappers from existing `.abi` files — and do not need `solc`, NodeJS or npm at all. Setting `compilerEnabled = false` makes that possible:

```groovy
solidity {
    compilerEnabled = false
}
```

With this flag disabled:
- the `compileSolidity` tasks are skipped, so no `solc` compiler is resolved, downloaded or executed;
- the `resolveSolidity` / `npmInstall` chain is never added to the task graph, so **NodeJS and npm are not required**.

To keep compilation but skip only the Node/npm integration, `resolvePackages = false` can be used instead.

### Changes included

#### `SolidityExtension.groovy`
- Add `Property<Boolean> getCompilerEnabled()` with a `true` convention default (preserving existing behaviour).

#### `SolidityPlugin.groovy`
- Add an `onlyIf { compilerEnabled.get() }` guard to the `SolidityCompile` task so compilation is skipped when disabled.
- Combine `compilerEnabled` with `resolvePackages` so the `resolveSolidity` / `npmInstall` chain is only pulled into the task graph when both compilation and package resolution are enabled.

#### `README.md`
- Add a **Applying the plugin without the compiler** section documenting `compilerEnabled`, and add `compilerEnabled` (and `viaIr`) to the DSL properties table.

#### `CHANGELOG.md`
- Add a changelog entry under the upcoming release's **Features** section.

#### `SolidityPluginTest.groovy`
- Add `disablingCompilerSkipsCompilationAndNode()` verifying that with `compilerEnabled = false` the build succeeds, `compileSolidity` is skipped, and `resolveSolidity` / `npmInstall` are never in the task graph.
- Add `disablingPackageResolutionSkipsNodeButStillCompiles()` verifying that `resolvePackages = false` disables only the Node/npm integration while compilation still runs.

---

## Where should the reviewer start?

1. `SolidityPlugin.configureSolidityCompile()` — the `onlyIf` guard and the `compilerEnabled`/`resolvePackages` combination that keeps `resolveSolidity` / `npmInstall` out of the task graph.
2. `SolidityExtension.groovy` — the new property and its default.
3. `SolidityPluginTest.disablingCompilerSkipsCompilationAndNode()` — validates the behaviour against a real Gradle build.

---

## Why is it needed?

Applying the plugin currently forces the Node/npm setup and the Solidity compile tasks onto every project, even when the user only wants to generate wrappers from pre-existing `.abi` files. That requires NodeJS and a `solc` download that are otherwise unused. The `compilerEnabled` property gives a first-class, declarative way to apply the plugin without any of that machinery, consistent with the rest of the `solidity` DSL.

---

## Verification

```bash
./gradlew test --tests "org.web3j.solidity.gradle.plugin.SolidityPluginTest.disablingCompilerSkipsCompilationAndNode" \
               --tests "org.web3j.solidity.gradle.plugin.SolidityPluginTest.disablingPackageResolutionSkipsNodeButStillCompiles"
```

Full suite (after merging latest `main`):

```
SolidityPluginTest > disablingCompilerSkipsCompilationAndNode() PASSED
SolidityPluginTest > disablingPackageResolutionSkipsNodeButStillCompiles() PASSED

16 tests passed, 2 skipped (env-gated: Executable, Docker)
BUILD SUCCESSFUL
```

<!-- TODO: paste screenshot of the passing test run here -->
<img width="1295" alt="test run" src="" />

---

## Issues fixed / related

- Fixes #74

---

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
